### PR TITLE
Fallover to main bundle if configuration file not found in class bundle

### DIFF
--- a/Source/Abstraction/MagnetDelegate.m
+++ b/Source/Abstraction/MagnetDelegate.m
@@ -73,14 +73,6 @@ NSString  * const MMXMessageFailureBlockKey = @"MMXMessageFailureBlockKey";
 }
 
 - (void)startMMXClientWithConfiguration:(NSString *)name {
-	//You must include your Configurations.plist file in the project. You can download this file on the Settings page of the Magnet Message Console
-	
-	NSString *pathAndFileName = [[NSBundle bundleForClass:[self class]] pathForResource:@"Configurations" ofType:@"plist"];
-	BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:pathAndFileName];
-	if (!exists) {
-		NSAssert(exists, @"You must include your Configurations.plist file in the project. You can download this file on the Settings page of the Magnet Message Web Interface");
-	}
-	
 	if ([MMXClient sharedClient].connectionStatus != MMXConnectionStatusAuthenticated &&
 		[MMXClient sharedClient].connectionStatus != MMXConnectionStatusConnected) {
 		[MMXClient sharedClient].shouldSuspendIncomingMessages = YES;

--- a/Source/Configuration/MMXConfigurationRegistry.h
+++ b/Source/Configuration/MMXConfigurationRegistry.h
@@ -25,5 +25,6 @@
 
 */
 + (NSDictionary *)sharedConfigurationRegistry;
++ (NSString *)pathForConfiguration;
 
 @end

--- a/Source/Configuration/MMXConfigurationRegistry.m
+++ b/Source/Configuration/MMXConfigurationRegistry.m
@@ -27,11 +27,27 @@
     dispatch_once(&onceToken, ^{
         [[MMXLogger sharedLogger] verbose:@"Reading settings from Configurations.plist"];
 
-        NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"Configurations" ofType:@"plist"];
-        _sharedConfiguration = [NSDictionary dictionaryWithContentsOfFile:path];
+        _sharedConfiguration = [NSDictionary dictionaryWithContentsOfFile:[MMXConfigurationRegistry pathForConfiguration]];
     });
 
     return _sharedConfiguration;
+}
+
++(NSString *)pathForConfiguration{
+    NSString *filename = @"Configurations";
+    
+    NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:filename ofType:@"plist"];
+    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:path];
+    if (!exists) {
+        //Try to fallover to mainBundle
+        path = [[NSBundle mainBundle] pathForResource:filename ofType:@"plist"];
+
+        exists = [[NSFileManager defaultManager] fileExistsAtPath:path];
+        if (!exists) {
+            NSAssert(exists, @"You must include your Configurations.plist file in the project. You can download this file on the Settings page of the Magnet Message Web Interface");
+        }
+    }
+    return path;
 }
 
 @end


### PR DESCRIPTION
This PR resolves an issue where `use_frameworks!` creates a separate bundle for each framework, making the main bundle configuration file inaccessible through `bundleForClass`.