### PR TITLE
Return fully-hydrated subscribers

### DIFF
--- a/Source/PubSub/TopicSubscription/MMXTopicSubscribersResponse.h
+++ b/Source/PubSub/TopicSubscription/MMXTopicSubscribersResponse.h
@@ -21,7 +21,7 @@
 @interface MMXTopicSubscribersResponse : NSObject
 
 @property (nonatomic, assign) int totalCount;
-@property (nonatomic, strong) NSArray *subscribers;
+@property (nonatomic, strong) NSArray <NSString *>*subscribers;
 
 - (instancetype)initWithIQ:(XMPPIQ *)iq;
 

--- a/Source/PubSub/TopicSubscription/MMXTopicSubscribersResponse.m
+++ b/Source/PubSub/TopicSubscription/MMXTopicSubscribersResponse.m
@@ -24,29 +24,22 @@
 @implementation MMXTopicSubscribersResponse
 
 - (instancetype)initWithIQ:(XMPPIQ *)iq {
-	if ((self = [super init])) {
-		NSXMLElement* mmxElement =  [iq elementForName:MXmmxElement xmlns:MXnsPubSub];
-		if (mmxElement) {
-			NSString* jsonContent =  [[mmxElement childAtIndex:0] XMLString];
-			NSError* error;
-			NSData* jsonData = [jsonContent dataUsingEncoding:NSUTF8StringEncoding];
-			NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-			if (jsonDictionary[@"totalCount"]) {
-				_totalCount = [jsonDictionary[@"totalCount"] intValue];
-			}
-			if (jsonDictionary[@"subscribers"]) {
-				NSArray *tempSubArray = jsonDictionary[@"subscribers"];
-				NSMutableArray *finalSubArray = [NSMutableArray arrayWithCapacity:tempSubArray.count];
-				for (NSDictionary *userDict in tempSubArray) {
-					MMUser *user = [MMUser new];
-					user.userName = userDict[kAddressUsernameKey];
-					[finalSubArray addObject:user];
-				}
-				_subscribers = finalSubArray.copy;
-			}
-		}
-	}
-	return self;
+    if ((self = [super init])) {
+        NSXMLElement* mmxElement =  [iq elementForName:MXmmxElement xmlns:MXnsPubSub];
+        if (mmxElement) {
+            NSString* jsonContent =  [[mmxElement childAtIndex:0] XMLString];
+            NSError* error;
+            NSData* jsonData = [jsonContent dataUsingEncoding:NSUTF8StringEncoding];
+            NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+            if (jsonDictionary[@"totalCount"]) {
+                _totalCount = [jsonDictionary[@"totalCount"] intValue];
+            }
+            if (jsonDictionary[@"subscribers"]) {
+                _subscribers = [jsonDictionary[@"subscribers"] valueForKey:kAddressUsernameKey];
+            }
+        }
+    }
+    return self;
 }
 
 @end


### PR DESCRIPTION
`subscribersWithLimit:offset:success:failure:` was not returning fully-hydrated `MMUser`s