### PR TITLE
Adding default push config for polls and poll answers

### DIFF
--- a/Source/Constants/MMXConstants.h
+++ b/Source/Constants/MMXConstants.h
@@ -84,4 +84,9 @@ extern NSInteger const kMinPasswordLength;
 extern NSInteger const kMaxPasswordLength;
 extern NSUInteger const kMaxMessageSize;
 
+// Poll and Poll Answer configs
+extern NSString * const kQuestionKey;
+extern NSString * const kDefaultPollPushConfigNameKey;
+extern NSString * const kDefaultPollAnswerPushConfigNameKey;
+
 @end

--- a/Source/Constants/MMXConstants.m
+++ b/Source/Constants/MMXConstants.m
@@ -84,4 +84,9 @@ NSString * const kAddressUsernameKey = @"userId";
 NSString * const kAddressDeviceIDKey = @"devId";
 NSString * const kAddressDisplayNameKey = @"displayName";
 
+// Poll and Poll Answer configs
+NSString * const kQuestionKey = @"question";
+NSString * const kDefaultPollPushConfigNameKey = @"DefaultPollConfig";
+NSString * const kDefaultPollAnswerPushConfigNameKey = @"DefaultPollAnswerConfig";
+
 @end

--- a/Source/Poll/MMXPoll.swift
+++ b/Source/Poll/MMXPoll.swift
@@ -163,7 +163,7 @@ extension Array where Element : Hashable {
         let surveyAnswerRequest = MMXSurveyAnswerRequest()
         surveyAnswerRequest.answers = answers
         let call = MMXSurveyService().submitSurveyAnswers(self.pollID, body: surveyAnswerRequest, success: {
-            let msg = MMXMessage(toChannel: channel, messageContent: [:])
+            let msg = MMXMessage(toChannel: channel, messageContent: [kQuestionKey: self.question], pushConfigName: kDefaultPollAnswerPushConfigNameKey)
             let result = MMXPollAnswer(self, selectedOptions: option, previousSelection: previousSelection)
             msg.payload = result
             self.myVotes = option
@@ -225,7 +225,7 @@ extension Array where Element : Hashable {
     //MARK: Public Static Methods
     //MARK: Publish
     public func publish(channel channel: MMXChannel,success: ((MMXMessage) -> Void)?, failure: ((error: NSError) -> Void)?) {
-        let msg = MMXMessage(toChannel: channel, messageContent: [:])
+        let msg = MMXMessage(toChannel: channel, messageContent: [kQuestionKey: question], pushConfigName: kDefaultPollPushConfigNameKey)
         publish(message: msg, success: success, failure: failure)
     }
     


### PR DESCRIPTION
@jimxj @lstanii-magnet @vampserv @sthiruppathy Please review.

Every poll will use a default push config **DefaultPollConfig:**

```
mmx.pubsub.notification.body=Poll: ${msg.content.question[0..*30]}
```

Every poll answer will use a default push config **DefaultPollAnswerConfig**

```
mmx.pubsub.notification.body=${msg.from} voted on ${msg.content.question[0..*30]}
```

These would be non-silent pushes.
